### PR TITLE
Add new root queries to GraphQL

### DIFF
--- a/src/DevChatter.DevStreams.Core/Services/IChannelSearchService.cs
+++ b/src/DevChatter.DevStreams.Core/Services/IChannelSearchService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using DevChatter.DevStreams.Core.Model;
 
 namespace DevChatter.DevStreams.Core.Services
@@ -6,5 +7,6 @@ namespace DevChatter.DevStreams.Core.Services
     public interface IChannelSearchService
     {
         List<Channel> Find();
+        Task<Channel> GetChannelSoundex(string standardizedChannelName);
     }
 }

--- a/src/DevChatter.DevStreams.Infra.Dapper/Services/ChannelSearchService.cs
+++ b/src/DevChatter.DevStreams.Infra.Dapper/Services/ChannelSearchService.cs
@@ -1,12 +1,12 @@
 ﻿using Dapper;
 using DevChatter.DevStreams.Core.Model;
+using DevChatter.DevStreams.Core.Services;
 using DevChatter.DevStreams.Core.Settings;
 using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
-using DevChatter.DevStreams.Core.Services;
 using System.Threading.Tasks;
 
 namespace DevChatter.DevStreams.Infra.Dapper.Services
@@ -45,13 +45,13 @@ namespace DevChatter.DevStreams.Infra.Dapper.Services
 
         public async Task<Channel> GetChannelSoundex(string standardizedChannelName)
         {
-            var sql = @"SELECT * FROM Channels WHERE SOUNDEX(Name) = SOUNDEX(@standardizedChannelName) 
+            var sql = @"SELECT TOP 1 * FROM Channels WHERE SOUNDEX(Name) = SOUNDEX(@standardizedChannelName) 
                         ORDER BY DIFFERENCE(Name, @standardizedChannelName) DESC";
-            using (System.Data.IDbConnection connection = new SqlConnection(_dbSettings.DefaultConnection))
+            using (IDbConnection connection = new SqlConnection(_dbSettings.DefaultConnection))
             {
                 using (var multi = await connection.QueryMultipleAsync(sql, new { standardizedChannelName }))
                 {
-                    return (await multi.ReadAsync<Channel>()).FirstOrDefault();
+                    return (await multi.ReadAsync<Channel>()).SingleOrDefault();
                 }
             }
         }

--- a/src/DevChatter.DevStreams.Infra.Dapper/Services/ChannelSearchService.cs
+++ b/src/DevChatter.DevStreams.Infra.Dapper/Services/ChannelSearchService.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using DevChatter.DevStreams.Core.Services;
+using System.Threading.Tasks;
 
 namespace DevChatter.DevStreams.Infra.Dapper.Services
 {
@@ -39,6 +40,19 @@ namespace DevChatter.DevStreams.Infra.Dapper.Services
                 }
 
                 return channels;
+            }
+        }
+
+        public async Task<Channel> GetChannelSoundex(string standardizedChannelName)
+        {
+            var sql = @"SELECT * FROM Channels WHERE SOUNDEX(Name) = SOUNDEX(@standardizedChannelName) 
+                        ORDER BY DIFFERENCE(Name, @standardizedChannelName) DESC";
+            using (System.Data.IDbConnection connection = new SqlConnection(_dbSettings.DefaultConnection))
+            {
+                using (var multi = await connection.QueryMultipleAsync(sql, new { standardizedChannelName }))
+                {
+                    return (await multi.ReadAsync<Channel>()).FirstOrDefault();
+                }
             }
         }
     }


### PR DESCRIPTION
Here are two new root queries for GraphQL, both needed for my Alexa skill:

- **channelSoundex(name: "")**: this query will return a channel where the channel's name is the best soundex match to the name supplied as an argument. For example, supplying _codebasealfa_ as the argument should return the channel information for _codebasealpha_. The name passed in should be in lowercase and have all spaces and periods removed.

![image](https://user-images.githubusercontent.com/7979108/56456390-81141580-6363-11e9-818e-27e901db46be.png)


-  **liveChannels**: returns a list of channels that are currently live (on Twitch only currently)

![image](https://user-images.githubusercontent.com/7979108/56456381-5aee7580-6363-11e9-81c3-564860502136.png)

The Alexa skill will use these queries to find channels based upon voice input, and to inform the skill user of channels that are currently live.