### PR TITLE
Fix logic error in ChannelType

### DIFF
--- a/src/DevChatter.DevStreams.Infra.GraphQL/Types/ChannelType.cs
+++ b/src/DevChatter.DevStreams.Infra.GraphQL/Types/ChannelType.cs
@@ -132,7 +132,7 @@ namespace DevChatter.DevStreams.Infra.GraphQL.Types
 
             var streamsNotInZone = scheduleLookup
                 .SelectMany(x => x)
-                .Where(stream => stream.TimeZoneId.Equals(_timeZone));
+                .Where(stream => !stream.TimeZoneId.Equals(_timeZone));
 
             foreach (ScheduledStream stream in streamsNotInZone)
             {


### PR DESCRIPTION
Logical error in Channel type, found whilst on-stream on Monday:

Changed line 135:
`.Where(stream => stream.TimeZoneId.Equals(_timeZone));`
To:
`.Where(stream => !stream.TimeZoneId.Equals(_timeZone));`