### PR TITLE
On the Channels page, don't display tags as "available" if all channels have that tag.

### DIFF
--- a/src/DevChatter.DevStreams.Web/wwwroot/js/vue/channels-index.js
+++ b/src/DevChatter.DevStreams.Web/wwwroot/js/vue/channels-index.js
@@ -26,7 +26,7 @@
         availableTags: function() {
             const selectedTags = this.searchFilters.selectedTags;
             return this.tags
-                .filter(tag => tag.count > 0 && selectedTags.indexOf(tag) === -1)
+                .filter(tag => tag.count > 0 && selectedTags.indexOf(tag) === -1 && tag.count < this.channels.length)
                 .sort((a,b) => b.count - a.count);
         }
     },


### PR DESCRIPTION
```JS
.filter(tag => tag.count > 0 && selectedTags.indexOf(tag) === -1)
```

Modified the existing logic above to:

```JS
.filter(tag => tag.count > 0 && selectedTags.indexOf(tag) === -1 && tag.count < this.channels.length)
```

I feel like this was too easy and I *MUST* be missing something.  I'm also secretly hoping that it was fine and VueJS is really this easy. 😄 
