### PR TITLE
Add a GraphQL query to get in-use tags

### DIFF
--- a/src/DevChatter.DevStreams.Core/Services/ITagService.cs
+++ b/src/DevChatter.DevStreams.Core/Services/ITagService.cs
@@ -8,5 +8,6 @@ namespace DevChatter.DevStreams.Core.Services
     public interface ITagService
     {
         Task<ILookup<int, Tag>> GetChannelTagsLookup(IEnumerable<int> channelIds);
+        Task<List<Tag>> GetTagsInUse();
     }
 }

--- a/src/DevChatter.DevStreams.Infra.Dapper/Services/TagService.cs
+++ b/src/DevChatter.DevStreams.Infra.Dapper/Services/TagService.cs
@@ -47,5 +47,17 @@ namespace DevChatter.DevStreams.Infra.Dapper.Services
                        .ToLookup(pair => pair.Key, pair => pair.Value);
             }
         }
+
+        public async Task<List<Tag>> GetTagsInUse()
+        {
+            const string sql = "SELECT * FROM Tags WHERE Id in (SELECT DISTINCT TagId FROM ChannelTags)";
+
+            using (IDbConnection connection = new SqlConnection(_dbSettings.DefaultConnection))
+            {
+                var tagsUsedByChannels = (await connection.QueryAsync<Tag>(sql)).ToList();
+
+                return tagsUsedByChannels;
+            }
+        }
     }
 }

--- a/src/DevChatter.DevStreams.Infra.GraphQL/DevStreamsQuery.cs
+++ b/src/DevChatter.DevStreams.Infra.GraphQL/DevStreamsQuery.cs
@@ -16,7 +16,7 @@ namespace DevChatter.DevStreams.Infra.GraphQL
         private readonly ITwitchStreamService _twitchService;
 
         public DevStreamsQuery(IChannelRepository channelRepo, ITwitchStreamService twitchService,
-            IChannelSearchService channelSearchService)
+            IChannelSearchService channelSearchService, ITagService tagService)
         {
             _channelRepo = channelRepo;
             _twitchService = twitchService;
@@ -62,6 +62,11 @@ namespace DevChatter.DevStreams.Infra.GraphQL
                 resolve: ctx =>
                 {
                     return GetLiveChannels();
+                });
+            Field<ListGraphType<TagType>>("tagsInUse",
+                resolve: ctx =>
+                {
+                    return tagService.GetTagsInUse();
                 });
         }
 


### PR DESCRIPTION
This PR adds a query to the GraphQL endpoint that will return all tags that are in-use by channels in the database. This query is for the use of clients that wish to display tags for users to select when searching for channels of interest. Rather than getting all available Tags, it is better to only get those that at least one channel is actually using.

![image](https://user-images.githubusercontent.com/7979108/57192660-da1aa680-6f2a-11e9-85a6-4863009e103c.png)
