### PR TITLE
[Issue #81] Fix for Vue.js template flash before component is mounted.

### DIFF
--- a/src/DevChatter.DevStreams.Web/Pages/Index.cshtml
+++ b/src/DevChatter.DevStreams.Web/Pages/Index.cshtml
@@ -4,7 +4,7 @@
 @{
     ViewData["Title"] = "Home page";
 }
-<div class="row" id="mainContent">
+<div class="row" style="display:none" v-bind:style="appstyles" id="mainContent">
     <div class="col-md-3">
         <h2>Live Now</h2> @*TODO: Show channels that are live right now.*@
         <ul>

--- a/src/DevChatter.DevStreams.Web/wwwroot/js/vue/home-page.js
+++ b/src/DevChatter.DevStreams.Web/wwwroot/js/vue/home-page.js
@@ -4,10 +4,12 @@
         liveChannelsIsLoaded: false,
         liveChannels : [],
         hasStream: false,
-        errorMessage: ''
+        errorMessage: '',
+        appstyles: { "display": "none" }
     },
     mounted() {
         this.fetchLiveChannels();
+        this.appstyles = { "display": "block"}
     },
     methods: {
         fetchLiveChannels: function () {


### PR DESCRIPTION
This PR fixed #81 is a fairly simple way, by adding display:none to the template, and changing the display to block once the component is mounted and ready to take over. 