### PR TITLE
Added GraphQL query channelsHavingTags

### DIFF
--- a/src/DevChatter.DevStreams.Core/Services/IChannelSearchService.cs
+++ b/src/DevChatter.DevStreams.Core/Services/IChannelSearchService.cs
@@ -1,4 +1,5 @@
 ﻿using DevChatter.DevStreams.Core.Model;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace DevChatter.DevStreams.Core.Services
@@ -6,5 +7,6 @@ namespace DevChatter.DevStreams.Core.Services
     public interface IChannelSearchService
     {
         Task<Channel> GetChannelSoundex(string standardizedChannelName);
+        Task<List<Channel>> GetChannelsByTagMatches(params int[] tagIds);
     }
 }

--- a/src/DevChatter.DevStreams.Infra.Dapper/Services/ChannelSearchService.cs
+++ b/src/DevChatter.DevStreams.Infra.Dapper/Services/ChannelSearchService.cs
@@ -3,6 +3,7 @@ using DevChatter.DevStreams.Core.Model;
 using DevChatter.DevStreams.Core.Services;
 using DevChatter.DevStreams.Core.Settings;
 using Microsoft.Extensions.Options;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
@@ -28,6 +29,28 @@ namespace DevChatter.DevStreams.Infra.Dapper.Services
                 using (var multi = await connection.QueryMultipleAsync(sql, new { standardizedChannelName }))
                 {
                     return (await multi.ReadAsync<Channel>()).SingleOrDefault();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get Channels By Tag IDs. Channel must have at least one of the tags.
+        /// </summary>
+        /// <param name="tagIds">Array of tag ids.</param>
+        /// <returns>List of Channels having at least one of the passed TagIds, order by most matches.</returns>
+        public async Task<List<Channel>> GetChannelsByTagMatches(params int[] tagIds)
+        {
+            var sql = @"SELECT c.[Id], c.[Name], c.[Uri], c.[CountryCode], c.[TimeZoneId]
+                            FROM Channels c, ChannelTags t
+                            WHERE c.Id = t.ChannelId
+                            AND t.TagId IN @tagIds
+                            GROUP BY c.[Id], c.[Name], c.[Uri], c.[CountryCode], c.[TimeZoneId]
+                            ORDER BY COUNT(*) DESC";
+            using (IDbConnection connection = new SqlConnection(_dbSettings.DefaultConnection))
+            {
+                using (var multi = await connection.QueryMultipleAsync(sql, new { tagIds }))
+                {
+                    return (await multi.ReadAsync<Channel>()).ToList();
                 }
             }
         }

--- a/src/DevChatter.DevStreams.Infra.GraphQL/DevStreamsQuery.cs
+++ b/src/DevChatter.DevStreams.Infra.GraphQL/DevStreamsQuery.cs
@@ -39,6 +39,20 @@ namespace DevChatter.DevStreams.Infra.GraphQL
                     return channelRepo.GetAll<Channel>();
                 });
 
+            Field<ListGraphType<ChannelType>>("channelsHavingTags",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<ListGraphType<IdGraphType>>>
+                    {
+                        Name = "tagIds",
+                        DefaultValue = new List<int>()
+                    }
+                ),
+                resolve: ctx =>
+                {
+                    List<int> tagIds = ctx.GetArgument<List<int>>("tagIds");
+                    return channelSearchService.GetChannelsByTagMatches(tagIds.ToArray());
+                });
+
             Field<ChannelType>("channel",
                 arguments: new QueryArguments(new QueryArgument<NonNullGraphType<IdGraphType>>
                 {

--- a/src/DevChatter.DevStreams.Web/Caching/CachedChannelSearchService.cs
+++ b/src/DevChatter.DevStreams.Web/Caching/CachedChannelSearchService.cs
@@ -2,6 +2,7 @@
 using DevChatter.DevStreams.Core.Services;
 using Microsoft.Extensions.Caching.Memory;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace DevChatter.DevStreams.Web.Caching
@@ -29,6 +30,22 @@ namespace DevChatter.DevStreams.Web.Caching
             {
                 entry.SetAbsoluteExpiration(TimeSpan.FromMinutes(15)); // TODO: Store in Config Setting
                 return _searchService.GetChannelSoundex(standardizedChannelName);
+            }
+        }
+
+        public async Task<List<Channel>> GetChannelsByTagMatches(params int[] tagIds)
+        {
+            string tags = string.Join("-", tagIds);
+            string cacheKey = $"{nameof(IChannelSearchService)}-{nameof(Task)}-{tags}";
+
+            var channels = await _cacheLayer.GetOrCreateAsync(cacheKey, CacheFallback);
+
+            return channels;
+
+            Task<List<Channel>> CacheFallback(ICacheEntry entry)
+            {
+                entry.SetAbsoluteExpiration(TimeSpan.FromMinutes(15)); // TODO: Store in Config Setting
+                return _searchService.GetChannelsByTagMatches(tagIds);
             }
         }
     }


### PR DESCRIPTION
This GraphQL query (`channelsHavingTags`) allows clients to pass in a list of Tag IDs, and be returned a list of channels that have one or more of those Tags, ordered by the greatest number of matching Tags, descending. In the example shown below, we pass in the Tag IDs for C# and JavaScript. The top result is `DevChatter`, which in the test database I am using, is tagged with both. Then we get `Codebase Alpha` (tagged with C#) and `Noopkat` (tagged with JavaScript):

![image](https://user-images.githubusercontent.com/7979108/57981695-e296d500-7a32-11e9-9045-1176e2e01a58.png)

This query is distinct from the current implementation of the `channels` query, where the channels must match ALL of the Tags passed in.